### PR TITLE
work around for Integer unification

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,24 @@
 PATH
   remote: .
   specs:
-    cow_proxy (0.2.0)
+    cow_proxy (0.2.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (9.0.6)
-    codeclimate-test-reporter (1.0.7)
-      simplecov
-    docile (1.1.5)
+    byebug (11.0.0)
+    codeclimate-test-reporter (1.0.9)
+      simplecov (<= 0.13)
+    docile (1.3.1)
     ice_nine (0.11.2)
-    json (2.0.3)
-    minitest (5.10.1)
-    rake (12.0.0)
+    json (2.2.0)
+    minitest (5.11.3)
+    rake (12.3.2)
     simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
+    simplecov-html (0.10.2)
 
 PLATFORMS
   ruby
@@ -33,4 +33,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.14.6
+   1.17.3

--- a/lib/cow_proxy.rb
+++ b/lib/cow_proxy.rb
@@ -127,11 +127,16 @@ end
 [Integer, Float, Symbol, TrueClass, FalseClass, NilClass].each do |klass|
   CowProxy.register_proxy klass, nil
 end
-if defined? Fixnum
-  CowProxy.register_proxy Fixnum, nil
-end
-if defined? Bignum
-  CowProxy.register_proxy Bignum, nil
+
+if 1.class == Integer
+  CowProxy.register_proxy Integer, nil
+else
+  if defined? Fixnum
+    CowProxy.register_proxy Fixnum, nil
+  end
+  if defined? Bignum
+    CowProxy.register_proxy Bignum, nil
+  end
 end
 
 require 'cow_proxy/base.rb'

--- a/lib/cow_proxy/version.rb
+++ b/lib/cow_proxy/version.rb
@@ -2,7 +2,7 @@ module CowProxy
   module Version
     MAJOR = 0
     MINOR = 2
-    PATCH = 0
+    PATCH = 1
 
     STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
gets rid of deprecation warning, avoids referencing Fixnum and Bignum.
