### PR TITLE
CI: Use 2.4.6, 2.5.5, 2.6.2, jruby-9.2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,17 @@ dist: trusty
 jdk:
   - openjdk7
 language: ruby
-rvm:
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.1
-  - jruby-9.1.15.0
-  - rbx-3
+
 matrix:
+  include:
+    - rvm: 2.3.8
+    - rvm: 2.4.6
+    - rvm: 2.5.5
+    - rvm: 2.6.2
+    - rvm: jruby-9.1.8.0
+    - rvm: jruby-9.2.7.0
+    - rvm: rbx-3
   allow_failures:
     - rvm: rbx-3
+    - rvm: jruby-9.1.8.0
+    - rvm: jruby-9.2.7.0


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known